### PR TITLE
Update Rector to latest version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "friendsofphp/php-cs-fixer": "^2.16.3",
         "phpstan/phpstan": "^0.12.28",
         "phpstan/phpstan-strict-rules": "^0.12.2",
-        "rector/rector": "^0.7.33",
+        "rector/rector": "^0.7.41",
         "symfony/var-dumper": "^5.1.0",
         "thecodingmachine/phpstan-strict-rules": "^0.12.0"
     },


### PR DESCRIPTION
This updates Rector to the latest version, which resolves the issue with [the Pest Init plugin CI](https://github.com/pestphp/pest-plugin-init/runs/818097537).

It looks like this was actually fixed in `v0.7.34`, but I think it's worth updating to the latest anyway. 🤷