### PR TITLE
chore(deps): update friendsofphp/php-cs-fixer to ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "ergebnis/phpstan-rules": "^0.15.3",
-        "friendsofphp/php-cs-fixer": "^2.18.3",
+        "friendsofphp/php-cs-fixer": "^3.0",
         "phpstan/phpstan": "^0.12.81",
         "phpstan/phpstan-strict-rules": "^0.12.9",
         "symfony/var-dumper": "^5.2.5",


### PR DESCRIPTION
This requires us to update to use a new config file name in our repositories, I'm going to go through and configure these.

- [x] [Pest](https://github.com/pestphp/pest) (https://github.com/pestphp/pest/pull/296)
- [x] [Website](https://github.com/pestphp/pestphp.com) (https://github.com/pestphp/pestphp.com/pull/20)
- [x] ~~[Drift](https://github.com/pestphp/drift)~~ Drift currently uses ECS instead of PHP-CS-Fixer
- [x] ~~[Dust](https://github.com/pestphp/dust)~~ Dust doesn't use PHP-CS-Fixer
- [x] [Dust Internals](https://github.com/pestphp/dust-internals) (https://github.com/pestphp/dust-internals/pull/1)
- [x] [Plugin](https://github.com/pestphp/pest-plugin) (https://github.com/pestphp/pest-plugin/pull/13)
- [x] Plugins
    - [x] [Coverage plugin](https://github.com/pestphp/pest-plugin-coverage) (https://github.com/pestphp/pest-plugin-coverage/pull/9)
    - [x] [Expectations plugin](https://github.com/pestphp/pest-plugin-expectations) (https://github.com/pestphp/pest-plugin-expectations/pull/6)
    - [x] [Faker plugin](https://github.com/pestphp/pest-plugin-faker) (https://github.com/pestphp/pest-plugin-faker/pull/9)
    - [x] [Global Assertions plugin](https://github.com/pestphp/pest-plugin-global-assertions) (https://github.com/pestphp/pest-plugin-global-assertions/pull/4)
    - [x] [Init plugin](https://github.com/pestphp/pest-plugin-init) (https://github.com/pestphp/pest-plugin-init/pull/14)
    - [x] [Laravel plugin](https://github.com/pestphp/pest-plugin-laravel) (https://github.com/pestphp/pest-plugin-laravel/pull/12)
    - [x] [Livewire plugin](https://github.com/pestphp/pest-plugin-livewire) (https://github.com/pestphp/pest-plugin-livewire/pull/11)
    - [x] [Symfony plugin](https://github.com/pestphp/pest-plugin-symfony) (https://github.com/pestphp/pest-plugin-symfony/pull/3)
    - [x] [Template plugin](https://github.com/pestphp/pest-plugin-template) (https://github.com/pestphp/pest-plugin-template/pull/8)
    - [x] [Watch plugin](https://github.com/pestphp/pest-plugin-watch) (https://github.com/pestphp/pest-plugin-watch/pull/14)

See: https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.0.0/UPGRADE-v3.md

**NOTE:** Need to update the Git attributes to prevent the new config being exported in Composer's dist releases.