### PR TITLE
Laravel 9 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "friendsofphp/php-cs-fixer": "^3.2.1",
         "phpstan/phpstan": "^1.1.2",
         "phpstan/phpstan-strict-rules": "^1.0.0",
-        "symfony/var-dumper": "^5.3.10",
+        "symfony/var-dumper": "^5.3.10 || ^6.0",
         "thecodingmachine/phpstan-strict-rules": "^1.0.0"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Adds symfony/var-dumper ^6.0 dependency

this will avoid dependency errors such this one:

![image](https://user-images.githubusercontent.com/8792274/149617596-c42efae5-e1a7-4848-a558-f8afa78b3764.png)
