### PR TITLE
chore(deps): update to the latest compatible versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
     ],
     "require": {
         "ergebnis/phpstan-rules": "^1.0.0",
-        "friendsofphp/php-cs-fixer": "^3.2.1",
-        "phpstan/phpstan": "^1.1.2",
-        "phpstan/phpstan-strict-rules": "^1.0.0",
-        "symfony/var-dumper": "^5.3.10 || ^6.0",
+        "friendsofphp/php-cs-fixer": "^3.4",
+        "phpstan/phpstan": "^1.4.7",
+        "phpstan/phpstan-strict-rules": "^1.1",
+        "symfony/var-dumper": "^5.4.5 || ^6.0",
         "thecodingmachine/phpstan-strict-rules": "^1.0.0"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
I've checked to make sure all these versions are still compatible with PHP 7.3 (for Pest 1.x) through to PHP 8.1

Once merged, we should be able to use the following patch on the main Pest repository:

<details>
<summary>Diff of required changes</summary>

```patch
diff --git a/src/Bootstrappers/BootFiles.php b/src/Bootstrappers/BootFiles.php
index 51781ff..5817c3a 100644
--- a/src/Bootstrappers/BootFiles.php
+++ b/src/Bootstrappers/BootFiles.php
@@ -48,6 +48,7 @@ final class BootFiles
             if (is_dir($filename)) {
                 $directory = new RecursiveDirectoryIterator($filename);
                 $iterator  = new RecursiveIteratorIterator($directory);
+                /** @var \DirectoryIterator $file */
                 foreach ($iterator as $file) {
                     $this->load($file->__toString());
                 }
diff --git a/src/Expectation.php b/src/Expectation.php
index 191d762..7703ebb 100644
--- a/src/Expectation.php
+++ b/src/Expectation.php
@@ -151,7 +151,6 @@ final class Expectation
             throw new BadMethodCallException('Expectation value is not iterable.');
         }

-        //@phpstan-ignore-next-line
         $value          = is_array($this->value) ? $this->value : iterator_to_array($this->value);
         $keys           = array_keys($value);
         $values         = array_values($value);
```

</details>