### PR TITLE
fix dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,9 @@
         }
     ],
     "require": {
+        "php": "^7.3 || ^8.0",
         "ergebnis/phpstan-rules": "^1.0.0",
-        "friendsofphp/php-cs-fixer": "^3.8.0",
+        "friendsofphp/php-cs-fixer": "^3.4.0",
         "phpstan/phpstan": "^1.6.8",
         "phpstan/phpstan-strict-rules": "^1.2.3",
         "symfony/var-dumper": "^5.4.5 || ^6.1",


### PR DESCRIPTION
this fix will bind php version to 7.3 in order to not let php-cs-fixer go beyond v3.4 then working on a PHP7.3 env

this will prevent our php7.3 tests workflows to fail:

![image](https://user-images.githubusercontent.com/8792274/186609723-5429c0a8-55a3-4506-acbc-0a4328fce825.png)
