### PR TITLE
Fix dependencies again

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "ergebnis/phpstan-rules": "^1.0.0",
-        "friendsofphp/php-cs-fixer": "^3.11",
+        "friendsofphp/php-cs-fixer": "^3.4",
         "phpstan/phpstan": "^1.8.5",
         "phpstan/phpstan-strict-rules": "^1.4.3",
         "symfony/var-dumper": "^5.4.5 || ^6.1.3",


### PR DESCRIPTION
@nunomaduro this PR will revert php-cs-fixer dependency to ^3.4

this was already fixed in #11 but reverted in https://github.com/pestphp/pest-dev-tools/commit/39903e853ebe5bd8083f6dfc53e589ee87f4c84b, breaking workflows for PHP7.3 in Pest core

