### PR TITLE
allow symfony/var-dumper 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "laravel/pint": "^1.24.0",
         "phpstan/phpstan": "^2.1.22",
         "phpstan/phpstan-strict-rules": "^2.0.6",
-        "symfony/var-dumper": "^7.3.2",
+        "symfony/var-dumper": "^7.3.2|^8.0",
         "rector/rector": "^2.1.4",
         "phpunit/phpunit": "^12.3.5",
         "symplify/phpstan-rules": "^14.6.13"


### PR DESCRIPTION
i am not sure about this change and there consequences.
My goal is to allow the usage of symfony 8 in pest.